### PR TITLE
Allow for manually tiggering tests and lints

### DIFF
--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -1,5 +1,5 @@
 name: Checks
-on: fork
+on: workflow_dispatch
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
On fork doesn't have permission to run on new forks.