### PR TITLE
Add m1 support by using dashudson mysql images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   mysql:
-    image: mysql:5.7.22
+    image: public.ecr.aws/dashhudson/mysql:5.7.36
     environment:
       MYSQL_ROOT_PASSWORD: 'very_secure_password'
       MYSQL_DATABASE: 'connections_db'
@@ -19,7 +19,7 @@ services:
       - "3307:3306"
 
   mysql_test:
-    image: mysql:5.7.22
+    image: public.ecr.aws/dashhudson/mysql:5.7.36
     environment:
       MYSQL_ROOT_PASSWORD: 'very_secure_password'
       MYSQL_DATABASE: 'connections_db_test'


### PR DESCRIPTION
I tested a couple of submissions with this docker-compose file and I think that it's all that's needed to get it to work with m1